### PR TITLE
Fix: set CURLOPT_SSL_VERIFYHOST value to 2

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -110,7 +110,7 @@ abstract class Base
         curl_setopt($ch, CURLOPT_PORT, 443);
         curl_setopt($ch, CURLOPT_TIMEOUT, 60);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, true);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HEADER, false);
 


### PR DESCRIPTION
Support for value 1 removed in cURL 7.28.1.